### PR TITLE
Updating extension attribute ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated support for extension attributes to work with the classic API that
+  we're currently using.
+
 ## 2.3.0 - 2021-11-10
 
 ## Added

--- a/src/jamf/types.ts
+++ b/src/jamf/types.ts
@@ -357,8 +357,9 @@ export interface ComputerDetail {
 }
 
 export interface ExtensionAttribute {
-  definitionId: string;
-  values: string[];
+  id: number;
+  name: string;
+  value: string[];
 }
 
 export interface Configuration {

--- a/src/steps/devices/__snapshots__/converters.test.ts.snap
+++ b/src/steps/devices/__snapshots__/converters.test.ts.snap
@@ -50,15 +50,17 @@ Object {
         ],
         "extension_attributes": Array [
           Object {
-            "definitionId": "123",
-            "values": Array [
+            "id": 1,
+            "name": "123",
+            "value": Array [
               "foo123",
               "bar123",
             ],
           },
           Object {
-            "definitionId": "456",
-            "values": Array [
+            "id": 2,
+            "name": "456",
+            "value": Array [
               "foo456",
               "bar456",
             ],

--- a/src/steps/devices/converters.ts
+++ b/src/steps/devices/converters.ts
@@ -144,7 +144,7 @@ export function createComputerEntity({
   const extensionAttributes = {};
   if (detailData && detailData.extension_attributes) {
     for (const e of detailData?.extension_attributes) {
-      extensionAttributes['extensionAttribute.' + e.definitionId] = e.values;
+      extensionAttributes['extensionAttribute.' + e.name] = e.value;
     }
   }
 
@@ -245,9 +245,8 @@ export function createComputerEntity({
     computer.encrypted = encrypted(detailData);
     computer.gatekeeperStatus = detailData.hardware.gatekeeper_status;
     computer.gatekeeperEnabled = gatekeeperEnabled(detailData);
-    computer.systemIntegrityProtectionEnabled = systemIntegrityProtectionEnabled(
-      detailData,
-    );
+    computer.systemIntegrityProtectionEnabled =
+      systemIntegrityProtectionEnabled(detailData);
 
     const configurationProfiles = detailData.configuration_profiles
       .map((profile) => macOsConfigurationDetailByIdMap.get(profile.id))
@@ -263,12 +262,10 @@ export function createComputerEntity({
       );
 
       computer.firewallEnabled = collapseFirewallBoolean('EnableFirewall');
-      computer.firewallStealthModeEnabled = collapseFirewallBoolean(
-        'EnableStealthMode',
-      );
-      computer.firewallBlockAllIncoming = collapseFirewallBoolean(
-        'BlockAllIncoming',
-      );
+      computer.firewallStealthModeEnabled =
+        collapseFirewallBoolean('EnableStealthMode');
+      computer.firewallBlockAllIncoming =
+        collapseFirewallBoolean('BlockAllIncoming');
       computer.screensaverLockEnabled = collapsePayloadBoolean(
         configurationProfiles,
         'com.apple.screensaver',

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -318,12 +318,14 @@ export function createMockComputerDetail(): ComputerDetail {
     },
     extension_attributes: [
       {
-        definitionId: '123',
-        values: ['foo123', 'bar123'],
+        id: 1,
+        name: '123',
+        value: ['foo123', 'bar123'],
       },
       {
-        definitionId: '456',
-        values: ['foo456', 'bar456'],
+        id: 2,
+        name: '456',
+        value: ['foo456', 'bar456'],
       },
     ],
     groups_accounts: {


### PR DESCRIPTION
Updating how we're ingesting extension attributes.  This integration looks to be using the Jamf Classic API currently, so it needed tweaked slightly to begin pulling them in correctly.