### PR TITLE
INT-2277 - Fixing Firewall Settings

### DIFF
--- a/src/jamf/types.ts
+++ b/src/jamf/types.ts
@@ -343,6 +343,7 @@ export interface ComputerDetail {
     activation_lock: boolean;
     secure_boot_level: string;
     external_boot_level: string;
+    firewall_enabled: string;
   };
   configuration_profiles: Array<{
     id: number;

--- a/src/jamf/types.ts
+++ b/src/jamf/types.ts
@@ -343,7 +343,7 @@ export interface ComputerDetail {
     activation_lock: boolean;
     secure_boot_level: string;
     external_boot_level: string;
-    firewall_enabled: string;
+    firewall_enabled: boolean;
   };
   configuration_profiles: Array<{
     id: number;

--- a/src/steps/devices/__snapshots__/converters.test.ts.snap
+++ b/src/steps/devices/__snapshots__/converters.test.ts.snap
@@ -47,6 +47,7 @@ Object {
     "foo456",
     "bar456",
   ],
+  "firewallEnabled": false,
   "gatekeeperEnabled": true,
   "gatekeeperStatus": "App Store and identified developers",
   "id": "1",

--- a/src/steps/devices/converters.ts
+++ b/src/steps/devices/converters.ts
@@ -276,7 +276,8 @@ export function createComputerEntity({
     }
 
     // TODO:  Should we let the Security tab Firewall value override the above
-    // firewall data set by the profile (if one is attached)?
+    // firewall data set by the profile (if one is attached)?  In theory, they
+    // should always match
     if(detailData.security && detailData.security.firewall_enabled !== undefined) {
       computer.firewallEnabled = detailData.security.firewall_enabled;
     }

--- a/src/steps/devices/converters.ts
+++ b/src/steps/devices/converters.ts
@@ -60,7 +60,10 @@ function getMacOsFirewallProperties(data: OSXConfigurationDetailParsed) {
     return item.PayloadType === 'com.apple.security.firewall';
   }) as OSXConfigurationFirewallPayload;
 
-  if (!firewallPayload || !firewallPayload.PayloadEnabled) {
+  // I don't believe we need to check for firewallPayload.PayloadEnabled for
+  // com.apple.security.firewall.  In the current payload, it doesn't contain
+  // that value like other properties do.
+  if (!firewallPayload) {
     return;
   }
 
@@ -270,6 +273,12 @@ export function createComputerEntity({
         'com.apple.screensaver',
         'loginWindowIdleTime',
       );
+    }
+
+    // TODO:  Should we let the Security tab Firewall value override the above
+    // firewall data set by the profile (if one is attached)?
+    if(detailData.security && detailData.security.firewall_enabled !== undefined) {
+      computer.firewallEnabled = detailData.security.firewall_enabled;
     }
   }
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -295,6 +295,7 @@ export function createMockComputerDetail(): ComputerDetail {
       activation_lock: false,
       secure_boot_level: 'not supported',
       external_boot_level: 'not supported',
+      firewall_enabled: false,
     },
     software: {
       unix_executables: [],


### PR DESCRIPTION
It appears that the OS X Config payload has changed from Jamf.  It now looks like the below XML and does not contain a `PayloadEnabled` value.  I've removed the check of PayloadEnabled and it appears to have cleared up the issue based on the testing I'm able to do with our test account data.  Additionally, there is a firewall_enabled value in the Security tab for a Jamf computer entity.  I'm letting the security tab override the overall `firewallEnabled` property, but in theory they should match.

```
<dict>
        <key>BlockAllIncoming</key>
        <true />
        <key>EnableFirewall</key>
        <true />
        <key>EnableStealthMode</key>
        <true />
        <key>PayloadDisplayName</key>
        <string>Firewall</string>
        <key>PayloadIdentifier</key>
        <string>59DCE17C-F372-40E4-A01D-7932894F5954</string>
        <key>PayloadOrganization</key>
        <string>JupiterOne</string>
        <key>PayloadType</key>
        <string>com.apple.security.firewall</string>
        <key>PayloadUUID</key>
        <string>59DCE17C-F372-40E4-A01D-7932894F5954</string>
        <key>PayloadVersion</key>
        <integer>1</integer>
        <key>Applications</key>
        <array />
      </dict>
```
