### PR TITLE
clone osxConfiguration when setting as raw data

### DIFF
--- a/src/steps/devices/converters.ts
+++ b/src/steps/devices/converters.ts
@@ -95,7 +95,7 @@ export function createMacOsConfigurationEntity(
 ) {
   return createIntegrationEntity({
     entityData: {
-      source: data,
+      source: { ...data }, // prevent osx configuration map contents from getting mutated during rawData shrinking
       assign: {
         _key: generateEntityKey(
           Entities.MAC_OS_CONFIGURATION_PROFILE._type,


### PR DESCRIPTION
# Description
Clone osxConfiguration when passing as raw data to `#createIntegrationEntity`

## Summary
In the event of an upload error due to rawData size the object passed into rawData is mutated by the shrinking logic. 
We pass in data that is subsequently saved to the jobState and relied on by subsequent steps (fetch-computers). We believe that this is causing the integration to break in some cases. We are going to clone the configuration object to avoid this.

## Type of change

Please leave any irrelevant options unchecked.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [X] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [X] My changes properly paginate the target service provider's API
- [X] My changes properly handle rate limiting of the target service provider's
      API
- [X] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [X] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [X] I have updated the `CHANGELOG.md` file to describe my changes
- [X] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
