### PR TITLE
[INT-7758]: fix invalid osx configuration parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-jamf",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "A JupiterOne Integration for https://jamf.com",
   "repository": "https://github.com/jupiterone/graph-jamf",
   "license": "MPL-2.0",

--- a/src/jamf/types.ts
+++ b/src/jamf/types.ts
@@ -441,7 +441,7 @@ export interface OSXConfigurationScreensaverPayload
 }
 
 export interface OSXConfigurationDetailParsed extends OSXConfigurationDetail {
-  parsedPayload: OSXConfigurationPayload;
+  parsedPayload?: OSXConfigurationPayload;
 }
 
 export interface MobileDevice {

--- a/src/steps/devices/converters.ts
+++ b/src/steps/devices/converters.ts
@@ -57,6 +57,10 @@ export function createMobileDeviceEntity(
 }
 
 function getMacOsFirewallProperties(data: OSXConfigurationDetailParsed) {
+  if (data.parsedPayload === undefined) {
+    return;
+  }
+
   const firewallPayload = data.parsedPayload.PayloadContent.find((item) => {
     return item.PayloadType === 'com.apple.security.firewall';
   }) as OSXConfigurationFirewallPayload;
@@ -76,6 +80,10 @@ function getMacOsFirewallProperties(data: OSXConfigurationDetailParsed) {
 }
 
 function getMacOsScreensaverProperties(data: OSXConfigurationDetailParsed) {
+  if (data.parsedPayload === undefined) {
+    return;
+  }
+
   const screensaverPayload = data.parsedPayload.PayloadContent.find((item) => {
     return item.PayloadType === 'com.apple.screensaver';
   });
@@ -431,7 +439,7 @@ function collapsePayloadValue(
   let value = initialValue;
 
   for (const profile of configurationProfiles) {
-    const payload = profile.parsedPayload.PayloadContent.find((item) => {
+    const payload = profile?.parsedPayload?.PayloadContent.find((item) => {
       return item.PayloadType === payloadType;
     }) as OSXConfigurationPayloadItem;
 

--- a/src/steps/devices/index.ts
+++ b/src/steps/devices/index.ts
@@ -159,7 +159,15 @@ async function iterateMacOsConfigurationDetails(
   for (const profile of macOsConfigurationProfiles) {
     const details = await client.fetchOSXConfigurationProfileById(profile.id);
     const parsed = toOSXConfigurationDetailParsed(details);
-    await iteratee(profile, parsed);
+
+    if (parsed !== null) {
+      await iteratee(profile, parsed);
+    } else {
+      logger.info(
+        { profileId: profile.id },
+        'Could not parse OSX Configuration Details',
+      );
+    }
   }
 }
 

--- a/src/util/toOSXConfigurationParsed.test.ts
+++ b/src/util/toOSXConfigurationParsed.test.ts
@@ -1,0 +1,68 @@
+import { toOSXConfigurationDetailParsed } from './toOSXConfigurationParsed';
+
+describe('toOSXConfigurationDetailParsed()', () => {
+  describe('given an empty payload string', () => {
+    it('should return null', () => {
+      const result = toOSXConfigurationDetailParsed({
+        general: {
+          id: 1,
+          name: '',
+          description: '',
+          site: { id: 1, name: '' },
+          category: { id: 1, name: '' },
+          distribution_method: '',
+          user_removable: false,
+          level: '',
+          redeploy_on_update: '',
+          payloads: '',
+        },
+        scope: {
+          all_computers: false,
+          all_jss_users: false,
+        },
+      });
+
+      expect(result).toEqual(null);
+    });
+  });
+
+  describe('given a valid plist string payload', () => {
+    it('should parse it and return it', () => {
+      const result = toOSXConfigurationDetailParsed({
+        general: {
+          id: 1,
+          name: '',
+          description: '',
+          site: { id: 1, name: '' },
+          category: { id: 1, name: '' },
+          distribution_method: '',
+          user_removable: false,
+          level: '',
+          redeploy_on_update: '',
+          payloads: '<plist><string>Hello World</string></plist>',
+        },
+        scope: {
+          all_computers: false,
+          all_jss_users: false,
+        },
+      });
+
+      expect(result).toEqual({
+        general: {
+          category: { id: 1, name: '' },
+          description: '',
+          distribution_method: '',
+          id: 1,
+          level: '',
+          name: '',
+          payloads: '<plist><string>Hello World</string></plist>',
+          redeploy_on_update: '',
+          site: { id: 1, name: '' },
+          user_removable: false,
+        },
+        parsedPayload: 'Hello World',
+        scope: { all_computers: false, all_jss_users: false },
+      });
+    });
+  });
+});

--- a/src/util/toOSXConfigurationParsed.test.ts
+++ b/src/util/toOSXConfigurationParsed.test.ts
@@ -3,66 +3,17 @@ import { toOSXConfigurationDetailParsed } from './toOSXConfigurationParsed';
 describe('toOSXConfigurationDetailParsed()', () => {
   describe('given an empty payload string', () => {
     it('should return null', () => {
-      const result = toOSXConfigurationDetailParsed({
-        general: {
-          id: 1,
-          name: '',
-          description: '',
-          site: { id: 1, name: '' },
-          category: { id: 1, name: '' },
-          distribution_method: '',
-          user_removable: false,
-          level: '',
-          redeploy_on_update: '',
-          payloads: '',
-        },
-        scope: {
-          all_computers: false,
-          all_jss_users: false,
-        },
-      });
-
+      const result = toOSXConfigurationDetailParsed('');
       expect(result).not.toBeDefined();
     });
   });
 
   describe('given a valid plist string payload', () => {
     it('should parse it and return it', () => {
-      const result = toOSXConfigurationDetailParsed({
-        general: {
-          id: 1,
-          name: '',
-          description: '',
-          site: { id: 1, name: '' },
-          category: { id: 1, name: '' },
-          distribution_method: '',
-          user_removable: false,
-          level: '',
-          redeploy_on_update: '',
-          payloads: '<plist><string>Hello World</string></plist>',
-        },
-        scope: {
-          all_computers: false,
-          all_jss_users: false,
-        },
-      });
-
-      expect(result).toEqual({
-        general: {
-          category: { id: 1, name: '' },
-          description: '',
-          distribution_method: '',
-          id: 1,
-          level: '',
-          name: '',
-          payloads: '<plist><string>Hello World</string></plist>',
-          redeploy_on_update: '',
-          site: { id: 1, name: '' },
-          user_removable: false,
-        },
-        parsedPayload: 'Hello World',
-        scope: { all_computers: false, all_jss_users: false },
-      });
+      const result = toOSXConfigurationDetailParsed(
+        '<plist><string>Hello World</string></plist>',
+      );
+      expect(result).toEqual('Hello World');
     });
   });
 });

--- a/src/util/toOSXConfigurationParsed.test.ts
+++ b/src/util/toOSXConfigurationParsed.test.ts
@@ -22,7 +22,7 @@ describe('toOSXConfigurationDetailParsed()', () => {
         },
       });
 
-      expect(result).toEqual(null);
+      expect(result).not.toBeDefined();
     });
   });
 

--- a/src/util/toOSXConfigurationParsed.ts
+++ b/src/util/toOSXConfigurationParsed.ts
@@ -1,22 +1,11 @@
 import plist from 'plist';
-import {
-  OSXConfigurationDetail,
-  OSXConfigurationDetailParsed,
-  OSXConfigurationPayload,
-} from '../jamf/types';
+import { OSXConfigurationPayload, PListDocument } from '../jamf/types';
 
 export function toOSXConfigurationDetailParsed(
-  detail: OSXConfigurationDetail,
-): OSXConfigurationDetailParsed | undefined {
+  payloads: PListDocument,
+): OSXConfigurationPayload | undefined {
   try {
-    const payload = plist.parse(
-      detail.general.payloads,
-    ) as unknown as OSXConfigurationPayload;
-
-    return {
-      ...detail,
-      parsedPayload: payload,
-    };
+    return plist.parse(payloads) as unknown as OSXConfigurationPayload;
   } catch (err) {
     return;
   }

--- a/src/util/toOSXConfigurationParsed.ts
+++ b/src/util/toOSXConfigurationParsed.ts
@@ -7,7 +7,7 @@ import {
 
 export function toOSXConfigurationDetailParsed(
   detail: OSXConfigurationDetail,
-): OSXConfigurationDetailParsed | null {
+): OSXConfigurationDetailParsed | undefined {
   try {
     const payload = plist.parse(
       detail.general.payloads,
@@ -18,6 +18,6 @@ export function toOSXConfigurationDetailParsed(
       parsedPayload: payload,
     };
   } catch (err) {
-    return null;
+    return;
   }
 }

--- a/src/util/toOSXConfigurationParsed.ts
+++ b/src/util/toOSXConfigurationParsed.ts
@@ -7,13 +7,17 @@ import {
 
 export function toOSXConfigurationDetailParsed(
   detail: OSXConfigurationDetail,
-): OSXConfigurationDetailParsed {
-  const payload = plist.parse(
-    detail.general.payloads,
-  ) as unknown as OSXConfigurationPayload;
+): OSXConfigurationDetailParsed | null {
+  try {
+    const payload = plist.parse(
+      detail.general.payloads,
+    ) as unknown as OSXConfigurationPayload;
 
-  return {
-    ...detail,
-    parsedPayload: payload,
-  };
+    return {
+      ...detail,
+      parsedPayload: payload,
+    };
+  } catch (err) {
+    return null;
+  }
 }


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Summary

- toOSXConfigurationDetailParsed fails when an invalid xml string is provided

## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ x New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
