### PR TITLE
fix auto packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "npm",
         {
           "setRcToken": false,
-          "publishFolder": "."
+          "publishFolder": "./dist"
         }
       ],
       "released"


### PR DESCRIPTION
We were not pointing at the dist directory when publishing