### PR TITLE
INT-8568/normalize-devices-os-versions

### DIFF
--- a/src/steps/devices/converters.ts
+++ b/src/steps/devices/converters.ts
@@ -19,6 +19,7 @@ import {
 } from '../../jamf/types';
 import { generateEntityKey } from '../../util/generateKey';
 import { Entities, DEPLOYMENT_STATUS } from '../constants';
+import { deviceNormalizer } from './normalizer';
 
 export function createMobileDeviceEntity(
   device: MobileDevice,
@@ -79,7 +80,9 @@ export function createMobileDeviceEntity(
         ),
         capacity: deviceDetail?.general?.capacity,
         osType: deviceDetail?.general?.os_type,
-        osVersion: deviceDetail?.general?.os_version,
+        osVersion: deviceNormalizer.normalizeOsVersion(
+          deviceDetail?.general?.os_version,
+        ),
         locatorServiceEnabled:
           deviceDetail?.general?.device_locator_service_enabled,
         cloudBackupEnabled: deviceDetail?.general?.cloud_backup_enabled,

--- a/src/steps/devices/normalizer.test.ts
+++ b/src/steps/devices/normalizer.test.ts
@@ -1,0 +1,26 @@
+import { deviceNormalizer } from './normalizer';
+
+describe('Device Normalizer', () => {
+  describe('normalizeOsVersion()', () => {
+    describe('given a version without patch version', () => {
+      it('should set patch to 0', () => {
+        const result = deviceNormalizer.normalizeOsVersion('1.1');
+        expect(result).toEqual('1.1.0');
+      });
+    });
+
+    describe('given a version without minor version', () => {
+      it('should set both minor and patch to 0', () => {
+        const result = deviceNormalizer.normalizeOsVersion('1');
+        expect(result).toEqual('1.0.0');
+      });
+    });
+
+    describe('given an empty version', () => {
+      it('should return the same value', () => {
+        const result = deviceNormalizer.normalizeOsVersion('');
+        expect(result).toEqual('');
+      });
+    });
+  });
+});

--- a/src/steps/devices/normalizer.ts
+++ b/src/steps/devices/normalizer.ts
@@ -1,0 +1,13 @@
+const normalizeOsVersion = (osVersion: string): string => {
+  if (!osVersion) {
+    return osVersion;
+  }
+
+  const [major, minor = '0', patch = '0'] = osVersion.split('.');
+
+  return [major, minor, patch].join('.');
+};
+
+export const deviceNormalizer = {
+  normalizeOsVersion,
+};


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Summary

<!-- Summary here! -->

## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
