### PR TITLE
DEVICE-107 -  ensure displayName is provided on all Device entities

### DIFF
--- a/src/steps/devices/converters.ts
+++ b/src/steps/devices/converters.ts
@@ -243,7 +243,8 @@ export function createComputerEntity({
     _class: Entities.COMPUTER._class,
     _rawData: [{ name: 'default', rawData: device }],
     id: device.udid.toString(),
-    displayName: device.name,
+    displayName:
+      device.name || `${device.username || 'Unknown User'}'s ${device.model}`,
     name: device.name,
     realName: detailData?.location.real_name || detailData?.location.realname,
     managed: device.managed,


### PR DESCRIPTION
`displayName` on computer entities will default to the username and the model when a device name is not provided.
